### PR TITLE
Step by step execution

### DIFF
--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -219,7 +219,7 @@ describe('Blockchain', () => {
     it('execution result in step by step mode should match one in regular mode', async() => {
         // Bounces are the most common case where step by step execution makes sense, so let's do the same test in step by step.
 
-        const blockchain = await Blockchain.create();
+        const blockchain = await Blockchain.create()
 
         const address = randomAddress()
 
@@ -235,9 +235,9 @@ describe('Blockchain', () => {
             .endCell()
 
         // Make sure time is not ticking
-        blockchain.now = 42;
+        blockchain.now = 42
 
-        const prevState = blockchain.snapshot();
+        const prevState = blockchain.snapshot()
 
         const testMsg = internal({
             from: new Address(0, Buffer.alloc(32)),
@@ -248,22 +248,22 @@ describe('Blockchain', () => {
         })
         const res  = await blockchain.sendMessage(testMsg)
         // Rolling back
-        await blockchain.loadFrom(prevState);
+        await blockchain.loadFrom(prevState)
         // Get iterable insead of iterator
         const iter = await blockchain.sendMessageIter(testMsg, false)
 
-        const stepByStepResults : BlockchainTransaction[] = [];
+        const stepByStepResults : BlockchainTransaction[] = []
 
-        for await (let tx of iter) {
-            stepByStepResults.push(tx);
+        for await (const tx of iter) {
+            stepByStepResults.push(tx)
         }
         // Length should match
-        expect(stepByStepResults.length).toEqual(res.transactions.length);
+        expect(stepByStepResults.length).toEqual(res.transactions.length)
         // Transactions order and content should match
         for(let i = 0; i < res.transactions.length; i++) {
-            expect(compareTransaction(flattenTransaction(res.transactions[i]), flattenTransaction(stepByStepResults[i]))).toBe(true);
+            expect(compareTransaction(flattenTransaction(res.transactions[i]), flattenTransaction(stepByStepResults[i]))).toBe(true)
         }
-    });
+    })
 
     it('should correctly return treasury balance', async () => {
         const blockchain = await Blockchain.create()
@@ -573,7 +573,7 @@ describe('Blockchain', () => {
         if (res.description.type !== 'tick-tock')
             throw new Error('Tick tock transaction expected')
         expect(res.description.isTock).toBe(false)
-    });
+    })
 
     it('should chain tick tock transaction output', async () => {
         class TestWrapper implements Contract {

--- a/src/blockchain/Blockchain.spec.ts
+++ b/src/blockchain/Blockchain.spec.ts
@@ -250,7 +250,7 @@ describe('Blockchain', () => {
         // Rolling back
         await blockchain.loadFrom(prevState)
         // Get iterable insead of iterator
-        const iter = await blockchain.sendMessageIter(testMsg, false)
+        const iter = await blockchain.sendMessageIter(testMsg)
 
         const stepByStepResults : BlockchainTransaction[] = []
 

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -180,18 +180,18 @@ export class Blockchain {
         await this.pushMessage(message)
         return await this.runQueue(params)
     }
-    async sendMessageIter(message: Message | Cell, iterator: true, params?: MessageParams): Promise<AsyncIterator<BlockchainTransaction>>;
+    async sendMessageIter(message: Message | Cell, iterator: true, params?: MessageParams): Promise<AsyncIterator<BlockchainTransaction>>
 
-    async sendMessageIter(message: Message | Cell, iterator: false, params?: MessageParams): Promise<AsyncIterable<BlockchainTransaction>>;
+    async sendMessageIter(message: Message | Cell, iterator: false, params?: MessageParams): Promise<AsyncIterable<BlockchainTransaction>>
     async sendMessageIter(message: Message | Cell, iterator: boolean, params?: MessageParams) {
         params = {
             now: this.now,
             ...params,
         }
 
-        await this.pushMessage(message);
+        await this.pushMessage(message)
         // Iterable will lock on per tx bases
-        return iterator ? await this.txIter(false, params) : await this.txIterable(false, params);
+        return iterator ? await this.txIter(false, params) : await this.txIterable(false, params)
     }
 
     async runTickTock(on: Address | Address[], which: TickOrTock, params?: MessageParams): Promise<SendMessageResult> {
@@ -241,27 +241,27 @@ export class Blockchain {
     }
 
     protected txIterable(locked: boolean, params?: MessageParams): AsyncIterable<BlockchainTransaction> {
-        const bc = this;
+        const bc = this
         return {
             [Symbol.asyncIterator] () {
-                return bc.txIter(locked, params);
+                return bc.txIter(locked, params)
             }
-        };
+        }
     }
     protected txIter(locked: boolean = true, params?: MessageParams): AsyncIterator<BlockchainTransaction> {
-        return { next: this.processTx.bind(this, locked, params) };
+        return { next: this.processTx.bind(this, locked, params) }
     }
     protected async processInternal(params?: MessageParams): Promise<IteratorResult<BlockchainTransaction>> {
-        let   result: BlockchainTransaction | undefined = undefined;
-        let   done = this.messageQueue.length == 0;
+        let   result: BlockchainTransaction | undefined = undefined
+        let   done = this.messageQueue.length == 0
         while (!done) {
             const message = this.messageQueue.shift()!
 
             let tx: SmartContractTransaction
             if (message.type === 'message') {
                 if (message.info.type === 'external-out') {
-                    done = this.messageQueue.length == 0;
-                    continue;
+                    done = this.messageQueue.length == 0
+                    continue
                 }
 
                 this.currentLt += LT_ALIGN
@@ -280,8 +280,8 @@ export class Blockchain {
             }
             transaction.parent?.children.push(transaction)
 
-            result = transaction;
-            done   = true;
+            result = transaction
+            done   = true
 
             for (const message of transaction.outMessages.values()) {
                 if (message.info.type === 'external-out') {
@@ -311,12 +311,12 @@ export class Blockchain {
             }
 
         }
-        return result === undefined ? {value: result, done: true } : {value: result, done: false };
+        return result === undefined ? {value: result, done: true } : {value: result, done: false }
     }
     protected async processTx(locked:boolean, params?: MessageParams): Promise<IteratorResult<BlockchainTransaction>> {
 
         // Lock only if not locked already
-        return locked ? await this.processInternal(params) : await this.lock.with(async () => this.processInternal(params));
+        return locked ? await this.processInternal(params) : await this.lock.with(async () => this.processInternal(params))
     }
     protected async processQueue(params?: MessageParams) {
         params = {
@@ -325,14 +325,14 @@ export class Blockchain {
         }
         return await this.lock.with(async () => {
             // Locked already
-            const txs = this.txIterable(true, params);
-            const result: BlockchainTransaction[] = [];
+            const txs = this.txIterable(true, params)
+            const result: BlockchainTransaction[] = []
 
-            for await (let tRes of txs) {
-                result.push(tRes);
+            for await (const tRes of txs) {
+                result.push(tRes)
             }
 
-            return result;
+            return result
         })
     }
 


### PR DESCRIPTION
# Description

Wrapping transactions execution in iterator provides more control during testing.
Current added functionality provides only step by step execution.
That later can be enhanced with conditional stop of execution for example.

Overall this can help with testing any kind of in between message states like bounce/race conditions/etc.
It can even help with reducing processing time of long transactions chain by stopping execution right after transaction of interest happened, rather than executing the full chain.

## Type of change

Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ x] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ x] Build succeeds locally with my changes
