### PR TITLE
feat: let prettyLogTransaction function to support address mapping

### DIFF
--- a/src/utils/prettyLogTransaction.ts
+++ b/src/utils/prettyLogTransaction.ts
@@ -1,24 +1,33 @@
 import {Transaction, fromNano} from "@ton/core";
+import {Address, ExternalAddress} from "@ton/core"
+import { Maybe } from "@ton/core/dist/utils/maybe";
 
-export function prettyLogTransaction(tx: Transaction) {
-    let res = `${tx.inMessage?.info.src!}  ➡️  ${tx.inMessage?.info.dest}\n`
+
+export function prettyLogTransaction(tx: Transaction, mapping?: Map<Address | Maybe<ExternalAddress>, string>) {
+    // Helper function to get the mapped address or default to the original
+    const getMappedAddress = (address: Address | Maybe<ExternalAddress>): string => {
+        return mapping?.get(address) ?? `${address}`;
+    };
+
+    let res = `${getMappedAddress(tx.inMessage?.info.src!)}  ➡️  ${getMappedAddress(tx.inMessage?.info.dest)}\n`;
 
     for (let message of tx.outMessages.values()) {
+        const dest = getMappedAddress(message.info.dest);
         if (message.info.type === 'internal') {
-            res += `     ➡️  ${fromNano(message.info.value.coins)} 💎 ${message.info.dest}\n`
+            res += `     ➡️  ${fromNano(message.info.value.coins)} 💎 ${dest}\n`;
         } else {
-            res += `      ➡️  ${message.info.dest}\n`
+            res += `      ➡️  ${dest}\n`;
         }
     }
 
-    return res
+    return res;
 }
 
-export function prettyLogTransactions(txs: Transaction[]) {
+export function prettyLogTransactions(txs: Transaction[], mapping?: Map<Address | Maybe<ExternalAddress>, string>) {
     let out = ''
 
     for (let tx of txs) {
-        out += prettyLogTransaction(tx) + '\n\n'
+        out += prettyLogTransaction(tx, mapping) + '\n\n'
     }
 
     console.log(out)


### PR DESCRIPTION
# Description

As a Tact / funC smart contract developers, when I want to conduct a deeper check if the test failed, I would like to use `prettyLogTransactions` to show the TON transfer flow. However,  the output of the original prettyLogTransactions contains only addresses, in some scenarios that more than 10 addresses involved in is indeed hard to debug. Thus, I wish to have a optional address mapping mechanism to help me tagging those addresses to be easily to understand with a nickname.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Build succeeds locally with my changes
