### PR TITLE
Async fetch fix

### DIFF
--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -201,6 +201,7 @@ export class Blockchain {
      */
     async loadFrom(snapshot: BlockchainSnapshot) {
         this.storage.clearKnownContracts()
+        this.contractFetches.clear();
         for (const contract of snapshot.contracts) {
             const storageContract = await this.getContract(contract.address)
             storageContract.loadFrom(contract)

--- a/src/blockchain/Blockchain.ts
+++ b/src/blockchain/Blockchain.ts
@@ -201,7 +201,7 @@ export class Blockchain {
      */
     async loadFrom(snapshot: BlockchainSnapshot) {
         this.storage.clearKnownContracts()
-        this.contractFetches.clear();
+        this.contractFetches.clear()
         for (const contract of snapshot.contracts) {
             const storageContract = await this.getContract(contract.address)
             storageContract.loadFrom(contract)


### PR DESCRIPTION
# Description

In asynchronous testing scenario, there could be the case where fetch is [added](https://github.com/ton-org/sandbox/blob/53627bddedc5f6c9aea5234ea03a75ef937cd078/src/blockchain/Blockchain.ts#L449) to a map, but the processing of the message, and clearance of fetch map is not yet started.

If we attempt to load snapshot, that references same contract from such state, it will cause contract state to be pulled from fetchMap instead of local storage.
This step will fail due to [address instance](https://github.com/ton-org/sandbox/blob/53627bddedc5f6c9aea5234ea03a75ef937cd078/src/blockchain/SmartContract.ts#L203) check.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Build succeeds locally with my changes
