### PR TITLE
fetchConfig and setGlobalVersion utils

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,11 @@ export {
 } from './utils/message';
 
 export {
+    fetchConfig,
+    setGlobalVersion
+} from './utils/config';
+
+export {
     ExtraCurrency,
 } from './utils/ec';
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,87 @@
+import { beginCell, Cell, Dictionary } from '@ton/core';
+
+export async function fetchConfig(network: 'mainnet' | 'testnet', maxRetries: number = 5) {
+    let apiDomain: string;
+    let retryLeft = maxRetries;
+
+    if(network == 'testnet') {
+        apiDomain = 'testnet.toncenter.com';
+    } else if(network == 'mainnet') {
+        apiDomain = 'toncenter.com';
+    } else {
+        throw new RangeError(`Unknown network: ${network}`);
+    }
+
+    const sleep = (timeout: number) => new Promise((resolve) => {
+        setTimeout(resolve, timeout);
+    });
+
+    const headers = new Headers();
+    headers.append("Accept", "application/json");
+
+    do {
+        try {
+            const resp = await fetch(`https://${apiDomain}/api/v2/getConfigAll`, {
+                method: 'GET',
+                headers
+            });
+
+            const jsonResp = await resp.json();
+            if(jsonResp.ok) {
+                return Cell.fromBase64(jsonResp.result.config.bytes);
+            } else {
+                throw new Error(JSON.stringify(jsonResp));
+            }
+        } catch(e: any) {
+            retryLeft--;
+            console.error(`Error fetching config:${e.toString()}`);
+            await sleep(1000);
+        }
+    } while(retryLeft > 0);
+
+    throw new Error(`Failed to fetch config after ${maxRetries} attempts`);
+}
+
+export function setGlobalVersion(config: Cell, version: number, capabilites?: bigint) {
+        const parsedConfig = Dictionary.loadDirect(
+            Dictionary.Keys.Int(32),
+            Dictionary.Values.Cell(),
+            config
+        );
+
+        let changed = false;
+
+        const param8 = parsedConfig.get(8);
+        if(!param8) {
+            throw new Error("[setTvmVersion] parameter 8 is not found!");
+        }
+
+        const ds = param8.beginParse();
+        const tag = ds.loadUint(8);
+        const curVersion = ds.loadUint(32);
+
+        const newValue = beginCell().storeUint(tag, 8);
+
+        if (curVersion != version) {
+            changed = true;
+        }
+        newValue.storeUint(version, 32);
+
+        if(capabilites) {
+            const curCapabilities = ds.loadUintBig(64);
+            if(capabilites != curCapabilities) {
+                changed = true;
+            }
+            newValue.storeUint(capabilites, 64);
+        } else {
+            newValue.storeSlice(ds);
+        }
+
+        // If any changes, serialize
+        if(changed) {
+            parsedConfig.set(8, newValue.endCell());
+            return beginCell().storeDictDirect(parsedConfig).endCell();
+        }
+
+        return config;
+}


### PR DESCRIPTION
# Description
Config utility functions

## fetchConfig
Allows to conveniently fetch the current network config
from the network.
Supports `mainnet` and `testnet`.
Uses [getConfigAll](https://toncenter.com/api/v2/#/get%20config/get_config_all_getConfigAll_get) Toncenter endpoint.

## setGlobalVersion
Allows to conveniently set [GlobalVersion](https://github.com/ton-blockchain/ton/blob/master/crypto/block/block.tlb#L630) values
without any manual operations.

Fixes # (issue)

## Type of change


- [ ] New feature (non-breaking change which adds functionality)

# Checklist:

- [ +] My code follows the style guidelines of this project
- [ +] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [+ ] New and existing unit tests pass locally with my changes
- [ +] Build succeeds locally with my changes
